### PR TITLE
:truck: TB2-1068 Deploy via CMDB

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
 String CONTAINERDIR = "."
 String CONTAINERNAME = "fixxx/thumbnail:${env.BUILD_NUMBER}"
 String DOCKERFILE = "Dockerfile"
+String PLAYBOOK = 'deploy.yml'
+String PLAYBOOKPARAMS = '-e cmdb_id=app_thumbnail'
 
 def tryStep(String message, Closure block, Closure tearDown = null) {
     try {
@@ -57,7 +59,8 @@ if (BRANCH == "master") {
                 build job: 'Subtask_Openstack_Playbook',
                         parameters: [
                                 [$class: 'StringParameterValue', name: 'INVENTORY', value: 'acceptance'],
-                                [$class: 'StringParameterValue', name: 'PLAYBOOK', value: 'deploy-thumbnail.yml'],
+                                [$class: 'StringParameterValue', name: 'PLAYBOOK', value: "${PLAYBOOK}"],
+                                [$class: 'StringParameterValue', name: 'PLAYBOOKPARAMS', value: "${PLAYBOOKPARAMS}"],
                         ]
             }
         }
@@ -86,7 +89,8 @@ if (BRANCH == "master") {
                 build job: 'Subtask_Openstack_Playbook',
                         parameters: [
                                 [$class: 'StringParameterValue', name: 'INVENTORY', value: 'production'],
-                                [$class: 'StringParameterValue', name: 'PLAYBOOK', value: 'deploy-thumbnail.yml'],
+                                [$class: 'StringParameterValue', name: 'PLAYBOOK', value: "${PLAYBOOK}"],
+                                [$class: 'StringParameterValue', name: 'PLAYBOOKPARAMS', value: "${PLAYBOOKPARAMS}"],
                         ]
             }
         }


### PR DESCRIPTION
The playbook `deploy-thumbnail.yml` has been removed. The container must now be deployed via the CMDB. This is the only functional change to this Jenkinsfile.
(The branches used for building and the strategy to deploy to Acceptance or Production remain the same as before.)